### PR TITLE
[#9] Implement Exception Handling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
   "rules": {
     "indent": ["error", 2],
     "linebreak-style": ["error", "unix"],
+    "no-throw-literal": "error",
     "quotes": ["error", "single"],
     "semi": ["error", "always"]
   }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -13,6 +13,13 @@ const PORT = 3000;
     res.send('Hello World! I am API server');
   });
 
+  // Default error handling
+  app.use((error: Error, _req: Request, res: Response) => {
+    console.error(error);
+
+    res.status(500).json(error.message);
+  });
+
   app.listen(PORT, () => {
     console.log('Server is running at port', PORT);
   });

--- a/api/src/models/Bulb/index.ts
+++ b/api/src/models/Bulb/index.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@lightbulbs/common';
 import { Category } from '../Category';
 import { Entity } from '../Entity';
 import { ModelStatus } from '../Entity/types';
@@ -116,7 +117,7 @@ export class Bulb extends Entity<IBulbData> {
     const add_function = (data: IBulbData | null, status: ModelStatus): IBulbData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot add a reference to empty data!');
+        throw new AppError('Cannot add a reference to empty data!');
       }
 
       // Get source's identifier. The source should already exist in database.
@@ -124,7 +125,7 @@ export class Bulb extends Entity<IBulbData> {
 
       // Ensure the reference has not been in the list.
       if (data.references.findIndex((reference) => reference.source.id === source_id) !== -1) {
-        throw Error('The reference to add already belongs to the bulb!');
+        throw new AppError('The reference to add already belongs to the bulb!');
       }
 
       data.references.push({
@@ -152,7 +153,7 @@ export class Bulb extends Entity<IBulbData> {
     const remove_function = (data: IBulbData | null, status: ModelStatus): IBulbData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot remove a reference from empty data!');
+        throw new AppError('Cannot remove a reference from empty data!');
       }
 
       // Get source's identifier. The source should already exist in database.
@@ -161,7 +162,7 @@ export class Bulb extends Entity<IBulbData> {
       // Ensure the reference is found in the list.
       const reference_index = data.references.findIndex((reference) => reference.source.id === source_id);
       if (reference_index === -1) {
-        throw Error('The reference to remove does not belong to the bulb!');
+        throw new AppError('The reference to remove does not belong to the bulb!');
       }
 
       data.references.splice(reference_index, 1);
@@ -184,7 +185,7 @@ export class Bulb extends Entity<IBulbData> {
     const add_function = (data: IBulbData | null, status: ModelStatus): IBulbData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot add a tag to empty data!');
+        throw new AppError('Cannot add a tag to empty data!');
       }
 
       // Get tag's identifier. The tag should already exist in database.
@@ -192,7 +193,7 @@ export class Bulb extends Entity<IBulbData> {
 
       // Ensure the tag has not been in the list.
       if (data.tags.findIndex((tag) => tag.id === tag_id) !== -1) {
-        throw Error('The tag to add already belongs to the bulb!');
+        throw new AppError('The tag to add already belongs to the bulb!');
       }
 
       data.tags.push({
@@ -217,7 +218,7 @@ export class Bulb extends Entity<IBulbData> {
     const remove_function = (data: IBulbData | null, status: ModelStatus): IBulbData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot remove a tag from empty data!');
+        throw new AppError('Cannot remove a tag from empty data!');
       }
 
       // Get tag's identifier. The tag should already exist in database.
@@ -226,7 +227,7 @@ export class Bulb extends Entity<IBulbData> {
       // Ensure the tag is found in the list.
       const tag_index = data.tags.findIndex((tag) => tag.id === tag_id);
       if (tag_index === -1) {
-        throw Error('The tag to remove does not belong to the bulb!');
+        throw new AppError('The tag to remove does not belong to the bulb!');
       }
 
       data.tags.splice(tag_index, 1);
@@ -249,7 +250,7 @@ export class Bulb extends Entity<IBulbData> {
     const archive_function = (data: IBulbData | null, status: ModelStatus): IBulbData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot archive content of empty data!');
+        throw new AppError('Cannot archive content of empty data!');
       }
 
       // Push the current version to the beginning of the list of past versions
@@ -288,7 +289,7 @@ export class Bulb extends Entity<IBulbData> {
  */
 function assertBulb(input: Partial<IBulb>): asserts input is IBulb {
   if (!input.title || !input.content || !input.category || !input.category.id) {
-    throw Error('The provided input is not a complete bulb type!');
+    throw new AppError('The provided input is not a complete bulb type!');
   }
 }
 
@@ -301,7 +302,7 @@ function extractEntityID(entity: Category | ReferenceSource | Tag): string {
   const entity_id = entity.getID();
 
   if (entity_id === null) {
-    throw Error('The ' + entity.name + ' does not exist in database!');
+    throw new AppError('The ' + entity.name + ' does not exist in database!');
   }
 
   return entity_id;

--- a/api/src/models/Bulb/operator/mongoose/index.ts
+++ b/api/src/models/Bulb/operator/mongoose/index.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@lightbulbs/common';
 import { FilterQuery, HydratedDocument, Types } from 'mongoose';
 import { MongoDBOperator } from '../../../Entity/operator/mongoose';
 import { IBulb, IBulbData, IBulbFilter } from '../../types';
@@ -189,7 +190,7 @@ async function loadBulbDoc(id: string): Promise<HydratedDocument<IRawBulbData>> 
   const doc = await BulbModel.findById(id);
 
   if (!doc) {
-    throw 'Documents not found!';
+    throw new AppError('Documents not found!');
   }
 
   return doc;

--- a/api/src/models/Category/index.ts
+++ b/api/src/models/Category/index.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@lightbulbs/common';
 import { Entity } from '../Entity';
 import { ModelStatus } from '../Entity/types';
 import { CategoryOperator } from './operator';
@@ -81,7 +82,7 @@ export class Category extends Entity<ICategoryData> {
     const increment_function = (data: ICategoryData | null, status: ModelStatus): ICategoryData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot increase total bulbs of empty data!');
+        throw new AppError('Cannot increase total bulbs of empty data!');
       }
 
       data.statistics.total_bulbs++;
@@ -104,12 +105,12 @@ export class Category extends Entity<ICategoryData> {
     const decrement_function = (data: ICategoryData | null, status: ModelStatus): ICategoryData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot decrease total bulbs of empty data!');
+        throw new AppError('Cannot decrease total bulbs of empty data!');
       }
 
       // Cannot be performed on zero or negative total.
       if (data.statistics.total_bulbs <= 0) {
-        throw Error('Invalid operation: total bulbs has already reached 0');
+        throw new AppError('Invalid operation: total bulbs has already reached 0');
       }
 
       data.statistics.total_bulbs--;
@@ -144,6 +145,6 @@ export class Category extends Entity<ICategoryData> {
  */
 function assertCategory(input: Partial<ICategory>): asserts input is ICategory {
   if (!input.name) {
-    throw Error('The provided input is not a complete category type!');
+    throw new AppError('The provided input is not a complete category type!');
   }
 }

--- a/api/src/models/Category/operator/mongoose/index.ts
+++ b/api/src/models/Category/operator/mongoose/index.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@lightbulbs/common';
 import { FilterQuery, HydratedDocument } from 'mongoose';
 import { MongoDBOperator } from '../../../Entity/operator/mongoose';
 import { ICategory, ICategoryData, ICategoryFilter } from '../../types';
@@ -120,7 +121,7 @@ async function loadCategoryDoc(id: string): Promise<HydratedDocument<ICategoryDa
   const doc = await CategoryModel.findById(id);
 
   if (!doc) {
-    throw 'Documents not found!';
+    throw new AppError('Documents not found!');
   }
 
   return doc;

--- a/api/src/models/Entity/index.ts
+++ b/api/src/models/Entity/index.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@lightbulbs/common';
 import { IDatabaseOperator } from './operator/types';
 import { IBaseEntityData, ModelStatus } from './types';
 
@@ -80,7 +81,7 @@ export abstract class Entity<DataType extends IBaseEntityData> {
   public async save(): Promise<void> {
     // Cannot be performed on an EMPTY model.
     if (this.data === null || this.status === ModelStatus.EMPTY) {
-      throw Error('Cannot perform save with empty data!');
+      throw new AppError('Cannot perform save with empty data!');
     }
 
     if (this.operator === null) {
@@ -124,7 +125,7 @@ export abstract class Entity<DataType extends IBaseEntityData> {
    */
   public async reload(): Promise<void> {
     if (!this.operator) {
-      throw Error('Cannot reload: data has never been loaded previously!');
+      throw new AppError('Cannot reload: data has never been loaded previously!');
     }
 
     await this.load(this.operator.getID());

--- a/api/src/models/ReferenceSource/index.ts
+++ b/api/src/models/ReferenceSource/index.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@lightbulbs/common';
 import { Entity } from '../Entity';
 import { ModelStatus } from '../Entity/types';
 import { ReferenceSourceOperator } from './operator';
@@ -83,7 +84,7 @@ export class ReferenceSource extends Entity<IReferenceSourceData> {
     const increment_function = (data: IReferenceSourceData | null, status: ModelStatus): IReferenceSourceData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot increase total bulbs of empty data!');
+        throw new AppError('Cannot increase total bulbs of empty data!');
       }
 
       data.statistics.total_bulbs++;
@@ -106,12 +107,12 @@ export class ReferenceSource extends Entity<IReferenceSourceData> {
     const decrement_function = (data: IReferenceSourceData | null, status: ModelStatus): IReferenceSourceData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot decrease total bulbs of empty data!');
+        throw new AppError('Cannot decrease total bulbs of empty data!');
       }
 
       // Cannot be performed on zero or negative total.
       if (data.statistics.total_bulbs <= 0) {
-        throw Error('Invalid operation: total bulbs has already reached 0');
+        throw new AppError('Invalid operation: total bulbs has already reached 0');
       }
 
       data.statistics.total_bulbs--;
@@ -146,6 +147,6 @@ export class ReferenceSource extends Entity<IReferenceSourceData> {
  */
 function assertReferenceSource(input: Partial<IReferenceSource>): asserts input is IReferenceSource {
   if (!input.name || !input.type) {
-    throw Error('The provided input is not a complete reference source type!');
+    throw new AppError('The provided input is not a complete reference source type!');
   }
 }

--- a/api/src/models/ReferenceSource/operator/mongoose/index.ts
+++ b/api/src/models/ReferenceSource/operator/mongoose/index.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@lightbulbs/common';
 import { FilterQuery, HydratedDocument } from 'mongoose';
 import { MongoDBOperator } from '../../../Entity/operator/mongoose';
 import { IReferenceSource, IReferenceSourceData, IReferenceSourceFilter } from '../../types';
@@ -138,7 +139,7 @@ async function loadReferenceSourceDoc(id: string): Promise<HydratedDocument<IRef
   const doc = await ReferenceSourceModel.findById(id);
 
   if (!doc) {
-    throw 'Documents not found!';
+    throw new AppError('Documents not found!');
   }
 
   return doc;

--- a/api/src/models/ReferenceSource/types.ts
+++ b/api/src/models/ReferenceSource/types.ts
@@ -53,11 +53,6 @@ export const ReferenceSourceTypes = [
 ] as const;
 
 /**
- * Available string values for reference source type.
- */
-export type IReferenceSourceType = (typeof ReferenceSourceTypes)[number];
-
-/**
  * The primary `ReferenceSource` data.
  */
 export interface IReferenceSource {

--- a/api/src/models/Tag/index.ts
+++ b/api/src/models/Tag/index.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@lightbulbs/common';
 import { Entity } from '../Entity';
 import { ModelStatus } from '../Entity/types';
 import { TagOperator } from './operator';
@@ -85,7 +86,7 @@ export class Tag extends Entity<ITagData> {
     const link_function = (data: ITagData | null, status: ModelStatus): ITagData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot link tag with empty data!');
+        throw new AppError('Cannot link tag with empty data!');
       }
 
       if (parent) {
@@ -93,9 +94,9 @@ export class Tag extends Entity<ITagData> {
         const parent_id = parent.getID();
 
         if (parent_id === null) {
-          throw Error('The tag referenced as parent does not exist in database!');
+          throw new AppError('The tag referenced as parent does not exist in database!');
         } else if (parent_id === data.id) {
-          throw Error('Cannot link a tag with itself!');
+          throw new AppError('Cannot link a tag with itself!');
         }
 
         data.parent = {
@@ -123,7 +124,7 @@ export class Tag extends Entity<ITagData> {
     const increment_function = (data: ITagData | null, status: ModelStatus): ITagData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot increase total bulbs of empty data!');
+        throw new AppError('Cannot increase total bulbs of empty data!');
       }
 
       data.statistics.total_bulbs++;
@@ -146,12 +147,12 @@ export class Tag extends Entity<ITagData> {
     const decrement_function = (data: ITagData | null, status: ModelStatus): ITagData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot decrease total bulbs of empty data!');
+        throw new AppError('Cannot decrease total bulbs of empty data!');
       }
 
       // Cannot be performed on zero or negative total.
       if (data.statistics.total_bulbs <= 0) {
-        throw Error('Invalid operation: total bulbs has already reached 0');
+        throw new AppError('Invalid operation: total bulbs has already reached 0');
       }
 
       data.statistics.total_bulbs--;
@@ -174,7 +175,7 @@ export class Tag extends Entity<ITagData> {
     const increment_function = (data: ITagData | null, status: ModelStatus): ITagData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot increase total children of empty data!');
+        throw new AppError('Cannot increase total children of empty data!');
       }
 
       data.statistics.total_children++;
@@ -197,12 +198,12 @@ export class Tag extends Entity<ITagData> {
     const decrement_function = (data: ITagData | null, status: ModelStatus): ITagData => {
       // Cannot be performed on an EMPTY model.
       if (data === null || status === ModelStatus.EMPTY) {
-        throw Error('Cannot decrease total children of empty data!');
+        throw new AppError('Cannot decrease total children of empty data!');
       }
 
       // Cannot be performed on zero or negative total.
       if (data.statistics.total_children <= 0) {
-        throw Error('Invalid operation: total children has already reached 0');
+        throw new AppError('Invalid operation: total children has already reached 0');
       }
 
       data.statistics.total_children--;
@@ -237,6 +238,6 @@ export class Tag extends Entity<ITagData> {
  */
 function assertTag(input: Partial<ITag>): asserts input is ITag {
   if (!input.label) {
-    throw Error('The provided input is not a complete tag type!');
+    throw new AppError('The provided input is not a complete tag type!');
   }
 }

--- a/api/src/models/Tag/operator/mongoose/index.ts
+++ b/api/src/models/Tag/operator/mongoose/index.ts
@@ -1,3 +1,4 @@
+import { AppError } from '@lightbulbs/common';
 import { FilterQuery, HydratedDocument, Types } from 'mongoose';
 import { MongoDBOperator } from '../../../Entity/operator/mongoose';
 import { ITag, ITagData, ITagFilter } from '../../types';
@@ -145,7 +146,7 @@ async function loadTagDoc(id: string): Promise<HydratedDocument<IRawTagData>> {
   const doc = await TagModel.findById(id);
 
   if (!doc) {
-    throw 'Documents not found!';
+    throw new AppError('Documents not found!');
   }
 
   return doc;

--- a/common/src/error/index.ts
+++ b/common/src/error/index.ts
@@ -1,0 +1,50 @@
+import { AppErrorCode, COMMON_ERROR_NAMES, ICommonErrorName } from './types';
+
+/**
+ * Class that extends standard `Error` for use within all applications.
+ */
+export class AppError extends Error {
+  code: AppErrorCode;
+  metadata: Record<string, any>;
+
+  /**
+   * Construct an error object with a number of parameter list options.
+   */
+  /**
+   * @overload The simple way, specify only the error message string.
+   * The error code and name will be initialized with default values.
+   * @param message The error message
+   */
+  constructor(message: string);
+  /**
+   * @overload Quick way to instantiate common errors, using pre-defined error names.
+   * The error code will be automatically derived from the error name.
+   * @param input.message The error message
+   * @param input.name The error name, pick one from list of common error names
+   */
+  constructor(input: string | { message: string; name: ICommonErrorName });
+  /**
+   * @overload The custom way, specify user-defined values for both error name and code.
+   * @param input.message The error message
+   * @param input.name The error name, can be any string
+   * @param input.code The error code
+   */
+  constructor(input: string | { message: string; name: string; code: AppErrorCode });
+  constructor(input: string | { message: string; name: string; code?: AppErrorCode }) {
+    if (typeof input === 'string') {
+      super(input);
+
+      this.code = AppErrorCode.UNKNOWN;
+      this.name = 'AppError';
+    } else {
+      const { message, name, code } = input;
+
+      super(message);
+
+      this.code = code || COMMON_ERROR_NAMES[name as ICommonErrorName];
+      this.name = name;
+    }
+
+    this.metadata = {};
+  }
+}

--- a/common/src/error/index.ts
+++ b/common/src/error/index.ts
@@ -22,14 +22,14 @@ export class AppError extends Error {
    * @param input.message The error message
    * @param input.name The error name, pick one from list of common error names
    */
-  constructor(input: string | { message: string; name: ICommonErrorName });
+  constructor(input: { message: string; name: ICommonErrorName });
   /**
-   * @overload The custom way, specify user-defined values for both error name and code.
+   * @overload The full custom way, specify user-defined values for both error name and code.
    * @param input.message The error message
    * @param input.name The error name, can be any string
    * @param input.code The error code
    */
-  constructor(input: string | { message: string; name: string; code: AppErrorCode });
+  constructor(input: { message: string; name: string; code: AppErrorCode });
   constructor(input: string | { message: string; name: string; code?: AppErrorCode }) {
     if (typeof input === 'string') {
       super(input);

--- a/common/src/error/types.ts
+++ b/common/src/error/types.ts
@@ -1,5 +1,5 @@
 /**
- * The code of the application error.
+ * The category code of the application error.
  */
 export enum AppErrorCode {
   UNKNOWN = 'UNKNOWN',

--- a/common/src/error/types.ts
+++ b/common/src/error/types.ts
@@ -1,0 +1,39 @@
+/**
+ * The code of the application error.
+ */
+export enum AppErrorCode {
+  UNKNOWN = 'UNKNOWN',
+  INPUT = 'INPUT',
+  ACTION = 'ACTION',
+  DATA = 'DATA',
+  CONNECTION = 'CONNECTION',
+  CONFIG = 'CONFIG',
+}
+
+/**
+ * Dictionary of common application error names and their corresponding error codes.
+ */
+export const COMMON_ERROR_NAMES = {
+  // INPUT errors
+  MissingInput: AppErrorCode.INPUT,
+  InvalidInput: AppErrorCode.INPUT,
+  // ACTION errors
+  InvalidPrecondition: AppErrorCode.ACTION,
+  UnauthorizedAccess: AppErrorCode.ACTION,
+  InsufficientPermission: AppErrorCode.ACTION,
+  // DATA errors
+  MissingData: AppErrorCode.DATA,
+  InvalidData: AppErrorCode.DATA,
+  // CONNECTION errors
+  DatabaseOutage: AppErrorCode.CONNECTION,
+  InternalServiceOutage: AppErrorCode.CONNECTION,
+  NoExternalResponse: AppErrorCode.CONNECTION,
+  // CONFIG errors
+  MissingConfig: AppErrorCode.CONFIG,
+  InvalidConfig: AppErrorCode.CONFIG,
+};
+
+/**
+ * Available string values for common application error names.
+ */
+export type ICommonErrorName = keyof typeof COMMON_ERROR_NAMES;

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,1 +1,10 @@
+/**
+ * Export explicit types
+ */
+export { AppErrorCode, ICommonErrorName } from './error/types';
+
+/**
+ * Export modules
+ */
+export * from './error';
 export * from './utils/config';

--- a/common/src/utils/config.ts
+++ b/common/src/utils/config.ts
@@ -1,5 +1,6 @@
 import { ValidateFunction } from 'ajv';
 import fs from 'fs';
+import { AppError } from '../error';
 
 /**
  * The global object containing records of loaded config.
@@ -35,7 +36,7 @@ export function loadConfigFromJSONFile<ConfigType extends object>(input: {
    * If the config file exists, load and parse.
    */
   if (!fs.existsSync(source)) {
-    throw Error(`Config file for "${name}" is not found at ${source}`);
+    throw new AppError(`Config file for "${name}" is not found at ${source}`);
   }
 
   const raw_config = fs.readFileSync(source, 'utf8');
@@ -47,7 +48,7 @@ export function loadConfigFromJSONFile<ConfigType extends object>(input: {
    */
   if (validate) {
     if (validate(config) === false) {
-      throw Error(`Loaded config for "${name}" is invalid. Errors: ${JSON.stringify(validate.errors)}`);
+      throw new AppError(`Loaded config for "${name}" is invalid. Errors: ${JSON.stringify(validate.errors)}`);
     }
   }
 


### PR DESCRIPTION
## Summary

### Description
- Added AppError class derived from standard JavaScript Error class
- Replaced all thrown exceptions with AppError
- Added default error handler in API server

### Linked issues
- Fulfills #9

## Details

### Code changes
- Added `error` folder in `common` workspace:
  - Defined `AppError` class by extending standard `Error` class
  - Defined enums and constants for error codes and names
- Updated `utils` folder in `api` workspace:
  - Replaced thrown exceptions with `AppError` in `loadConfigFromJSONFile()`
- Updated `models` folder in `api` workspace:
  - Replaced all thrown exceptions with `AppError`
  - Updated `ReferenceSource` sub-folder:
    - Removed type `IReferenceSourceType` as it resolves to being synonymous as `ReferenceSourceType` enum
- Updated server application in `api` workspace:
  - Added default error handling middleware
- Others:
  - Updated `.eslintrc.json`:
    - Add `no-throw-literal` rule to prevent throwing exception with literal values.

### Commentaries

The `AppError` class is derived from `Error` class and maintains API compatibility, which means replacing the latter with the former is as easy as replacing `new Error(...)` with `new AppError(...)`, no change in parameters.

Its main feature is the utilization of error `code`, `name`, and `metadata`.
- The `code` is an enum describing the category of error: whether it's related to `INPUT` (e.g. validation error), `ACTION` (e.g. forbidden action), `DATA` (e.g. data not found), and so on. The list can be expanded to include more categories if needed.
- The `name` is a normal string to quickly convey the idea of what is going wrong. Certain errors are quite common such as `InvalidInput` and `MissingData`. Using `name` to store these values helps to identify where the issue is and locate the related code.
- The `metadata` is used to store contextual and miscellaneous information which may help the investigation, though currently its practical use hasn't been defined yet in this PR. 

There are 3 ways of instantiating `AppError` object:

#### Basic instantiation

The simplest way is to instantiate it as one would with `Error` class:

``` TypeScript
throw new AppError('error message')`;
```

This will initializes `code` and `name` with default values, respectively `UNKNOWN` and `AppError`.

#### Full custom instantiation

This gives the caller flexibility to fully customize all the `AppError` attributes, by instantiating it with an object containing `message`, `code` and `name` properties:

``` TypeScript
throw new AppError({
    code: AppErrorCode.UNKNOWN,
    name: 'BrokenProcess',
    message: 'Process suddenly hangs!',
});
```

The caller fully controls whatever information is defined in the error, no default initialization is taking place.

#### Short instantiation

Sometimes it is too much of a hassle to always set the error `code` and `name` for every single exception. Also, there is a risk of having similar errors being defined in multiple different ways. For instance, the same failure to connect to a database is named `Database Error` in some places and `DB Unavailable` in other places. 

Some common errors are best defined with convention. To realize this, a dictionary of `COMMON_ERROR_NAMES` is added. The caller can pick from the list and provide the `name` during instantiation:

``` TypeScript
throw new AppError({
    name: 'InvalidInput',
    message: 'The input property "data" should be in JSON format!',
});
```

There is no need to provide the `code` as `AppError` will map the `name` to appropriate `code` and initialize it. In this instantiation, the `name` must match one of the entries in `COMMON_ERROR_NAMES`. Due to its promoting for consistency, this is the recommended way of `AppError` instantiation in most cases.