### PR TITLE
[#13] Implement API Route and Workflow Layer

### DIFF
--- a/api/src/common/route/index.ts
+++ b/api/src/common/route/index.ts
@@ -1,0 +1,56 @@
+import { NextFunction, Request, Response, Router } from 'express';
+import { formatHTTPSuccessResponse } from './response';
+import { HTTPMethod, IRouteController, IWorkflowInput } from './types';
+import { getValidator } from './validator';
+
+/**
+ * Register a controller into a router.
+ * @param router The Express router to host the controller.
+ * @param controller The controller configuration.
+ */
+export function buildRoute<InputType extends IWorkflowInput>(
+  router: Router,
+  controller: IRouteController<InputType>
+): void {
+  const { method, path, schema, workflow } = controller;
+
+  // If input schema is provided, generate an input validator from the shema.
+  const validator = schema ? getValidator(schema) : undefined;
+
+  // HTTP status code for success: 201 if a POST route, 200 otherwise
+  const http_success_code = method === HTTPMethod.POST ? 201 : 200;
+
+  // Compose the middlewares: validator and request handler
+  const middlewares = [
+    ...(validator ? [validator] : []),
+    async (req: Request, res: Response, next: NextFunction) => {
+      // Extract the input from the request
+      const input = {
+        ...(req.params ? { key: req.params } : {}),
+        ...(req.query ? { options: req.query } : {}),
+        ...(req.body ? { data: req.body } : {}),
+      } as InputType;
+
+      // Perform the workflow and return the formatted result
+      try {
+        const result = await workflow(input);
+
+        res.status(http_success_code).json(formatHTTPSuccessResponse(result));
+      } catch (e) {
+        // If there is any error, pass it to the error handler
+        next(e);
+      }
+    },
+  ];
+
+  // Register the middlewares to the destined path and method
+  if (method === HTTPMethod.GET) {
+    router.get(path, middlewares);
+  } else if (method === HTTPMethod.POST) {
+    router.post(path, middlewares);
+  } else if (method === HTTPMethod.PUT) {
+    router.put(path, middlewares);
+  } else if (method === HTTPMethod.PATCH) {
+    router.patch(path, middlewares);
+  }
+}

--- a/api/src/common/route/response.ts
+++ b/api/src/common/route/response.ts
@@ -1,5 +1,5 @@
-import { AppError } from '@lightbulbs/common';
-import { IHTTPResponse } from './types';
+import { AppError, AppErrorCode, ICommonErrorName } from '@lightbulbs/common';
+import { APP_ERROR_HTTP_STATUS_CODES, IHTTPResponse } from './types';
 
 /**
  * Format a successful workflow result into a standard HTTP response structure.
@@ -33,4 +33,28 @@ export function formatHTTPFailedResponse(error: AppError): IHTTPResponse {
     error: { code, name, message },
     meta: null,
   };
+}
+
+/**
+ * Determine the appropriate HTTP status code for the given application error.
+ * @param error The generated or thrown application error.
+ * @returns HTTP status code to return
+ */
+export function getHTTPStatusCode(error: AppError): number {
+  const { code, name } = error;
+
+  // If error name exists in the dictionary, return the mapped HTTP status code.
+  const http_status_code = APP_ERROR_HTTP_STATUS_CODES[name as ICommonErrorName];
+
+  if (http_status_code) {
+    return http_status_code;
+  }
+
+  // If the error is about the input, return Bad Request error as the most likely issue.
+  if (code === AppErrorCode.INPUT) {
+    return 400;
+  }
+
+  // Any other error types are undetermined, return default server error.
+  return 500;
 }

--- a/api/src/common/route/response.ts
+++ b/api/src/common/route/response.ts
@@ -1,0 +1,36 @@
+import { AppError } from '@lightbulbs/common';
+import { IHTTPResponse } from './types';
+
+/**
+ * Format a successful workflow result into a standard HTTP response structure.
+ * @param result The workflow result.
+ * @param context Optional information that explains the context of the result.
+ * @returns Structured HTTP response in JSON format.
+ */
+export function formatHTTPSuccessResponse<ResultType, ContextType>(
+  result: ResultType,
+  context?: ContextType
+): IHTTPResponse<ResultType, ContextType | null> {
+  return {
+    success: true,
+    data: result,
+    error: null,
+    meta: context || null,
+  };
+}
+
+/**
+ * Format an application error into a standard HTTP response structure.
+ * @param error The generated or thrown application error.
+ * @returns Structured HTTP response in JSON format.
+ */
+export function formatHTTPFailedResponse(error: AppError): IHTTPResponse {
+  const { code, name, message } = error;
+
+  return {
+    success: false,
+    data: null,
+    error: { code, name, message },
+    meta: null,
+  };
+}

--- a/api/src/common/route/response.ts
+++ b/api/src/common/route/response.ts
@@ -38,7 +38,7 @@ export function formatHTTPFailedResponse(error: AppError): IHTTPResponse {
 /**
  * Determine the appropriate HTTP status code for the given application error.
  * @param error The generated or thrown application error.
- * @returns HTTP status code to return
+ * @returns HTTP status code to return.
  */
 export function getHTTPStatusCode(error: AppError): number {
   const { code, name } = error;

--- a/api/src/common/route/types.ts
+++ b/api/src/common/route/types.ts
@@ -1,0 +1,67 @@
+import { JSONSchemaType } from 'ajv';
+
+/**
+ * The available HTTP methods.
+ */
+export enum HTTPMethod {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  PATCH = 'PATCH',
+}
+
+/**
+ * The standard HTTP response.
+ */
+export type IHTTPResponse<DataType = null, MetaType = null> =
+  | {
+      success: true;
+      data: DataType;
+      error: null;
+      meta: MetaType;
+    }
+  | {
+      success: false;
+      data: null;
+      error: {
+        code: string;
+        name: string;
+        message: string;
+      };
+      meta: null;
+    };
+
+/**
+ * The generic type for all workflow functions.
+ */
+export type IWorkflowFunction<InputType> = (input: InputType) => Promise<unknown>;
+
+/**
+ * The basic structure of a workflow function's input.
+ * @note Input is segmented into 3 properties:
+ * - `key` is the target's identifier
+ * - `data` is the payload
+ * - `options` is the configuration related to how the workflow is to be executed
+ */
+export type IWorkflowInput = Partial<Record<'key' | 'data' | 'options', unknown>>;
+
+/**
+ * The schema which represents the workflow function's input.
+ * @note Input is not mapped directly as a single JSON schema,
+ * rather a separate JSON schema is defined for each input property.
+ */
+export interface IWorkflowJSONSchema<InputType extends IWorkflowInput = IWorkflowInput> {
+  key?: JSONSchemaType<InputType['key']>;
+  data?: JSONSchemaType<InputType['data']>;
+  options?: JSONSchemaType<InputType['options']>;
+}
+
+/**
+ * The controller configuration that wires together a route, input schema, and workflow function.
+ */
+export interface IRouteController<InputType extends IWorkflowInput = IWorkflowInput> {
+  path: string;
+  method: HTTPMethod;
+  workflow: IWorkflowFunction<InputType>;
+  schema?: IWorkflowJSONSchema<InputType>;
+}

--- a/api/src/common/route/types.ts
+++ b/api/src/common/route/types.ts
@@ -1,3 +1,4 @@
+import { ICommonErrorName } from '@lightbulbs/common';
 import { JSONSchemaType } from 'ajv';
 
 /**
@@ -9,6 +10,24 @@ export enum HTTPMethod {
   PUT = 'PUT',
   PATCH = 'PATCH',
 }
+
+/**
+ * Dictionary of common application error names and their corresponding HTTP status codes.
+ */
+export const APP_ERROR_HTTP_STATUS_CODES: Record<ICommonErrorName, number> = {
+  MissingInput: 400,
+  InvalidInput: 400,
+  InvalidPrecondition: 409,
+  UnauthorizedAccess: 401,
+  InsufficientPermission: 403,
+  MissingData: 404,
+  InvalidData: 500,
+  DatabaseOutage: 500,
+  InternalServiceOutage: 504,
+  NoExternalResponse: 502,
+  MissingConfig: 500,
+  InvalidConfig: 500,
+};
 
 /**
  * The standard HTTP response.

--- a/api/src/common/route/types.ts
+++ b/api/src/common/route/types.ts
@@ -15,16 +15,24 @@ export enum HTTPMethod {
  * Dictionary of common application error names and their corresponding HTTP status codes.
  */
 export const APP_ERROR_HTTP_STATUS_CODES: Record<ICommonErrorName, number> = {
+  // Bad Request
   MissingInput: 400,
   InvalidInput: 400,
-  InvalidPrecondition: 409,
+  // Unauthorized
   UnauthorizedAccess: 401,
+  // Forbidden
   InsufficientPermission: 403,
+  // Not Found
   MissingData: 404,
+  // Conflict
+  InvalidPrecondition: 409,
+  // Bad Gateway
+  NoExternalResponse: 502,
+  // Gateway Timeout
+  InternalServiceOutage: 504,
+  // Internal Server Error
   InvalidData: 500,
   DatabaseOutage: 500,
-  InternalServiceOutage: 504,
-  NoExternalResponse: 502,
   MissingConfig: 500,
   InvalidConfig: 500,
 };

--- a/api/src/common/route/validator.ts
+++ b/api/src/common/route/validator.ts
@@ -8,6 +8,8 @@ import { IWorkflowInput, IWorkflowJSONSchema } from './types';
  * Configure AJV behavior for request input validator.
  */
 const ajv = new AJV({
+  // Return immediately once the first error is found.
+  allErrors: false,
   // Cast the data value to match the defined type.
   coerceTypes: true,
   // Replace missing properties with default values.

--- a/api/src/common/route/validator.ts
+++ b/api/src/common/route/validator.ts
@@ -1,0 +1,78 @@
+import AJV, { ErrorObject } from 'ajv';
+import { Request, Response, NextFunction } from 'express';
+import { AppError } from '@lightbulbs/common';
+import { formatHTTPFailedResponse } from './response';
+import { IWorkflowInput, IWorkflowJSONSchema } from './types';
+
+/**
+ * Configure AJV behavior for request input validator.
+ */
+const ajv = new AJV({
+  // Cast the data value to match the defined type.
+  coerceTypes: true,
+  // Replace missing properties with default values.
+  useDefaults: true,
+});
+
+/**
+ * The factory function that generates a validation middleware from the provided schema.
+ * @param schema The schema to validate the input against.
+ * @returns The validation middleware.
+ */
+export function getValidator<T extends IWorkflowInput>(
+  schema: IWorkflowJSONSchema<T>
+): (req: Request, res: Response, next: NextFunction) => void {
+  const validateKey = schema.key ? ajv.compile(schema.key) : null;
+  const validateData = schema.data ? ajv.compile(schema.data) : null;
+  const validateOptions = schema.options ? ajv.compile(schema.options) : null;
+
+  // Generate and return the middleware.
+  return (req: Request, res: Response, next: NextFunction) => {
+    let message_segments: Array<string> = [];
+    let validation_error: ErrorObject | null = null;
+
+    /**
+     * Validate the input, and auto-match the values when possible.
+     */
+    if (validateKey && !validateKey(req.params) && validateKey.errors) {
+      message_segments.push('Path:');
+      validation_error = validateKey.errors[0];
+    } else if (validateData && !validateData(req.body) && validateData.errors) {
+      message_segments.push('Body:');
+      validation_error = validateData.errors[0];
+    } else if (validateOptions && !validateOptions(req.query) && validateOptions.errors) {
+      message_segments.push('Query:');
+      validation_error = validateOptions.errors[0];
+    }
+
+    /**
+     * If all validation passes, forward to the next middleware.
+     */
+    if (validation_error === null) {
+      return next();
+    }
+
+    /**
+     * If there are validation errors, return Bad Request error.
+     */
+    const { instancePath, message, params } = validation_error;
+
+    const name = params.missingProperty ? 'MissingInput' : 'InvalidInput';
+    const property = instancePath.slice(1);
+
+    if (property.length > 0) {
+      message_segments.push(property);
+    }
+
+    if (message) {
+      message_segments.push(message);
+    }
+
+    const error = new AppError({
+      name,
+      message: message_segments.join(' '),
+    });
+
+    res.status(400).json(formatHTTPFailedResponse(error));
+  };
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,5 +1,8 @@
-import express, { Express, Request, Response } from 'express';
+import express, { Express, NextFunction, Request, Response } from 'express';
+import { AppError, AppErrorCode } from '@lightbulbs/common';
 import { getDatabaseClient } from './common/db';
+import { formatHTTPFailedResponse, getHTTPStatusCode } from './common/route/response';
+import { router } from './routes';
 
 const PORT = 3000;
 
@@ -9,15 +12,34 @@ const PORT = 3000;
 
   const app: Express = express();
 
-  app.get('/', (_req: Request, res: Response) => {
-    res.send('Hello World! I am API server');
+  app.use(express.json());
+
+  app.use('/', router);
+
+  // Invalid URL handling.
+  app.use((_req: Request, res: Response) => {
+    res.status(404).send();
   });
 
-  // Default error handling
-  app.use((error: Error, _req: Request, res: Response) => {
+  // Default error handling.
+  app.use((error: Error, _req: Request, res: Response, _next: NextFunction) => {
     console.error(error);
 
-    res.status(500).json(error.message);
+    // Ensure the error is standardized.
+    const app_error =
+      error instanceof AppError
+        ? error
+        : new AppError({
+            code: AppErrorCode.UNKNOWN,
+            name: 'AppError',
+            message: 'A problem has occurred',
+          });
+
+    // Derive the right HTTP status code.
+    const http_status_code = getHTTPStatusCode(app_error);
+
+    // Format and send the response.
+    res.status(http_status_code).json(formatHTTPFailedResponse(app_error));
   });
 
   app.listen(PORT, () => {

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -16,12 +16,22 @@ const PORT = 3000;
 
   app.use('/', router);
 
-  // Invalid URL handling.
-  app.use((_req: Request, res: Response) => {
-    res.status(404).send();
+  // Invalid URL handling
+  app.use((req: Request, res: Response) => {
+    console.error(`URL ${req.path} not found!`);
+
+    // Ensure the error is standardized.
+    const app_error = new AppError({
+      code: AppErrorCode.INPUT,
+      name: 'InvalidURL',
+      message: 'The URL for this resource is not found.',
+    });
+
+    // Format and send the response.
+    res.status(404).json(formatHTTPFailedResponse(app_error));
   });
 
-  // Default error handling.
+  // Default error handling
   app.use((error: Error, _req: Request, res: Response, _next: NextFunction) => {
     console.error(error);
 
@@ -32,7 +42,7 @@ const PORT = 3000;
         : new AppError({
             code: AppErrorCode.UNKNOWN,
             name: 'AppError',
-            message: 'A problem has occurred',
+            message: 'A problem has occurred.',
           });
 
     // Derive the right HTTP status code.

--- a/api/src/routes/bulb/index.ts
+++ b/api/src/routes/bulb/index.ts
@@ -1,0 +1,49 @@
+import { Router } from 'express';
+import { buildRoute } from '../../common/route';
+import { HTTPMethod } from '../../common/route/types';
+import { addBulb, IAddBulbInput } from '../../workflows/add/bulb';
+import { editBulb, IEditBulbInput } from '../../workflows/edit/bulb';
+import { fetchBulb, IFetchBulbInput } from '../../workflows/fetch/bulb';
+import { findBulbs } from '../../workflows/find/bulbs';
+import { ADD_BULB_INPUT_SCHEMA, EDIT_BULB_INPUT_SCHEMA } from './schemas';
+
+// Provide and export the router
+export const router = Router();
+
+/**
+ * GET /bulb/
+ */
+buildRoute(router, {
+  path: '/',
+  method: HTTPMethod.GET,
+  workflow: findBulbs,
+});
+
+/**
+ * POST /bulb/
+ */
+buildRoute<IAddBulbInput>(router, {
+  path: '/',
+  method: HTTPMethod.POST,
+  workflow: addBulb,
+  schema: ADD_BULB_INPUT_SCHEMA,
+});
+
+/**
+ * GET /bulb/:id
+ */
+buildRoute<IFetchBulbInput>(router, {
+  path: '/:id',
+  method: HTTPMethod.GET,
+  workflow: fetchBulb,
+});
+
+/**
+ * PATCH /bulb/:id
+ */
+buildRoute<IEditBulbInput>(router, {
+  path: '/:id',
+  method: HTTPMethod.PATCH,
+  workflow: editBulb,
+  schema: EDIT_BULB_INPUT_SCHEMA,
+});

--- a/api/src/routes/bulb/schemas.ts
+++ b/api/src/routes/bulb/schemas.ts
@@ -1,0 +1,79 @@
+import { IWorkflowJSONSchema } from '../../common/route/types';
+import { IAddBulbInput } from '../../workflows/add/bulb';
+import { IEditBulbInput } from '../../workflows/edit/bulb';
+
+/**
+ * JSON schema for addBulb input
+ */
+export const ADD_BULB_INPUT_SCHEMA: IWorkflowJSONSchema<IAddBulbInput> = {
+  data: {
+    type: 'object',
+    required: ['title', 'category', 'content'],
+    additionalProperties: false,
+    properties: {
+      title: { type: 'string' },
+      category: {
+        type: 'object',
+        required: ['id'],
+        additionalProperties: false,
+        properties: {
+          id: { type: 'string' },
+        },
+      },
+      content: { type: 'string' },
+      references: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['source', 'detail'],
+          properties: {
+            source: {
+              type: 'object',
+              required: ['id'],
+              properties: {
+                id: { type: 'string' },
+              },
+            },
+            detail: { oneOf: [{ type: 'string' }, { type: 'null', nullable: true }] },
+          },
+        },
+        default: [],
+      },
+      tags: {
+        type: 'array',
+        items: {
+          type: 'object',
+          required: ['id'],
+          properties: {
+            id: { type: 'string' },
+          },
+        },
+        default: [],
+      },
+    },
+  },
+};
+
+/**
+ * JSON schema for editBulb input
+ */
+export const EDIT_BULB_INPUT_SCHEMA: IWorkflowJSONSchema<IEditBulbInput> = {
+  key: {
+    type: 'object',
+    required: ['id'],
+    additionalProperties: false,
+    properties: {
+      id: { type: 'string' },
+    },
+  },
+  data: {
+    type: 'object',
+    required: [],
+    additionalProperties: false,
+    properties: {
+      title: { type: 'string', nullable: true },
+      content: { type: 'string', nullable: true },
+    },
+    anyOf: [{ required: ['title'] }, { required: ['content'] }],
+  },
+};

--- a/api/src/routes/index.ts
+++ b/api/src/routes/index.ts
@@ -1,0 +1,10 @@
+import { Request, Response, Router } from 'express';
+import { router as bulb_router } from './bulb';
+
+export const router = Router();
+
+router.use('/bulb', bulb_router);
+
+router.get('/', (_req: Request, res: Response) => {
+  res.send('Hello World! I am API server');
+});

--- a/api/src/workflows/add/bulb.ts
+++ b/api/src/workflows/add/bulb.ts
@@ -1,0 +1,81 @@
+import { Bulb } from '../../models/Bulb';
+import { IBulbData } from '../../models/Bulb/types';
+import { Category } from '../../models/Category';
+import { ReferenceSource } from '../../models/ReferenceSource';
+import { Tag } from '../../models/Tag';
+
+/**
+ * The input for `addBulb` workflow.
+ */
+export interface IAddBulbInput {
+  data: {
+    title: string;
+    category: {
+      id: string;
+    };
+    content: string;
+    references: Array<{
+      source: {
+        id: string;
+      };
+      detail: string | null;
+    }>;
+    tags: Array<{ id: string }>;
+  };
+}
+
+/**
+ * Workflow to create a new bulb.
+ * @param data The data of the bulb.
+ * @return Promise that resolves to the created bulb data.
+ */
+export async function addBulb({ data }: IAddBulbInput): Promise<IBulbData> {
+  /**
+   * Step #1: Load the dependency entities from the database.
+   */
+  const category = new Category();
+  await category.load(data.category.id);
+
+  const references = await Promise.all(
+    data.references.map(async ({ source, detail }) => {
+      const reference_source = new ReferenceSource();
+      await reference_source.load(source.id);
+
+      return { source: reference_source, detail };
+    })
+  );
+
+  const tags = await Promise.all(
+    data.tags.map(async ({ id }) => {
+      const tag = new Tag();
+      await tag.load(id);
+
+      return tag;
+    })
+  );
+
+  /**
+   * Step #2: Create the bulb model and link with the dependencies.
+   */
+  const bulb = new Bulb();
+
+  bulb.setData({
+    ...data,
+    category,
+  });
+
+  references.forEach((reference) => {
+    bulb.addReference(reference);
+  });
+
+  tags.forEach((tag) => {
+    bulb.addTag(tag);
+  });
+
+  /**
+   * Step #3: Insert the bulb record into the database and return it.
+   */
+  await bulb.save();
+
+  return bulb.getData() as IBulbData;
+}

--- a/api/src/workflows/edit/bulb.ts
+++ b/api/src/workflows/edit/bulb.ts
@@ -1,0 +1,42 @@
+import { Bulb } from '../../models/Bulb';
+import { IBulbData } from '../../models/Bulb/types';
+
+/**
+ * The input for `editBulb` workflow.
+ */
+export interface IEditBulbInput {
+  key: {
+    id: string;
+  };
+  data: {
+    title?: string;
+    content?: string;
+  };
+}
+
+/**
+ * Workflow to modify a bulb's data.
+ * @param key.id The identifier of the bulb.
+ * @param data The mutated data of the bulb.
+ * @return Promise that resolves to the updated bulb data.
+ */
+export async function editBulb({ key: { id }, data }: IEditBulbInput): Promise<IBulbData> {
+  /**
+   * Step #1: Load the bulb record from the database.
+   */
+  const bulb = new Bulb();
+
+  await bulb.load(id);
+
+  /**
+   * Step #2: Update the record and save to the database.
+   */
+  bulb.setData(data);
+
+  await bulb.save();
+
+  /**
+   * Step #3: Return the updated bulb record.
+   */
+  return bulb.getData() as IBulbData;
+}

--- a/api/src/workflows/fetch/bulb.ts
+++ b/api/src/workflows/fetch/bulb.ts
@@ -1,0 +1,71 @@
+import { Bulb } from '../../models/Bulb';
+import { IBulbData } from '../../models/Bulb/types';
+import { Category } from '../../models/Category';
+import { ICategoryData } from '../../models/Category/types';
+import { ReferenceSource } from '../../models/ReferenceSource';
+import { IReferenceSourceData } from '../../models/ReferenceSource/types';
+import { Tag } from '../../models/Tag';
+import { ITagData } from '../../models/Tag/types';
+
+/**
+ * The input for `fetchBulb` workflow.
+ */
+export interface IFetchBulbInput {
+  key: { id: string };
+}
+
+/**
+ * Workflow to retrieve a bulb's data.
+ * @param key.id The identifier of the bulb.
+ * @return Promise that resolves to the bulb data.
+ */
+export async function fetchBulb({ key: { id } }: IFetchBulbInput): Promise<IBulbData> {
+  /**
+   * Step #1: Load the bulb record from the database.
+   */
+  const bulb = new Bulb();
+
+  await bulb.load(id);
+
+  const data = bulb.getData() as IBulbData;
+
+  /**
+   * Step #2: Populate the data with the category detail.
+   */
+  const category = new Category();
+  await category.load(data.category.id);
+
+  /**
+   * Step #3: Populate the data with the reference sources details.
+   */
+  const references = await Promise.all(
+    data.references.map(async ({ source, detail }) => {
+      const reference_source = new ReferenceSource();
+      await reference_source.load(source.id);
+
+      return { source: reference_source, detail };
+    })
+  );
+
+  /**
+   * Step #4: Populate the data with the tags details.
+   */
+  const tags = await Promise.all(
+    data.tags.map(async ({ id }) => {
+      const tag = new Tag();
+      await tag.load(id);
+
+      return tag;
+    })
+  );
+
+  return {
+    ...data,
+    category: category.getData() as ICategoryData & { id: string },
+    references: references.map(({ source, detail }) => ({
+      source: source.getData() as IReferenceSourceData & { id: string },
+      detail,
+    })),
+    tags: tags.map((tag) => tag.getData() as ITagData & { id: string }),
+  };
+}

--- a/api/src/workflows/find/bulbs.ts
+++ b/api/src/workflows/find/bulbs.ts
@@ -1,0 +1,13 @@
+import { BulbOperator } from '../../models/Bulb/operator';
+import { IBulbData } from '../../models/Bulb/types';
+
+/**
+ * Workflow to search for bulbs matching the criteria.
+ * @return Promise that resolves to the list of bulbs.
+ */
+export async function findBulbs(): Promise<Array<Partial<IBulbData>>> {
+  /**
+   * Step #1: Retrieve all bulbs.
+   */
+  return await BulbOperator.findAll();
+}


### PR DESCRIPTION
## Summary

### Description
- Added route builder
  - Included schema validator
  - Included response formatter
- Added Bulb workflow functions
- Added Bulb routes using route builder
- Implemented default error handling for path not found and other common errors

### Linked issues
- Fulfills #13

## Details

### Code changes
- Updated `common` folder in `api` workspace:
  - Added `route` sub-folder:
    - Defined controller configuration that specifies the matching workflow function and input schema for a route
    - Added a function that converts the input schema into a validation middleware
    - Added standard HTTP response formatter (for both successful and failed request handling)
    - Added a builder function that turns the controller configuration into a complete route controller
    - Added a helper function to derive the HTTP status code of known errors 
- Added `workflows` folder in `api` workspace:
  - Added `add` sub-folder:
    - Added `addBulb` workflow
  - Added `edit` sub-folder:
    - Added `editBulb` workflow
  - Added `fetch` sub-folder:
    - Added `fetchBulb` workflow
  - Added `find` sub-folder:
    - Added `findBulbs` workflow
- Updated `routes` folder in `api` workspace:
  - Added `bulbs` sub-folder:
    - Defined AJV's JSON schemas for all available Bulb workflow inputs
    - Created Bulb controllers using the route builder (1 controller for each workflow)
  - Included Bulb controllers into the app router
- Added default handler for path not found
- Modified default error handler middleware to convert thrown errors into a structured response

### Commentaries

The introduction of the "workflow" layer requires some clarification. Is this a reference to the [workflow pattern](http://www.workflowpatterns.com/)? The answer is yes, though this layer is not aimed to be a faithful implementation of the pattern. The primary reasons for "borrowing" from this concept are:
- **Focus on the action, rather than the request-response cycle.** Stripped from all technicalities, an API request is simply a call for some work to be done. This broader perspective makes way for defining flexible, independent, and reusable units of execution known as the workflow functions. A workflow function can be triggered by any type of event; API request being just one of them. Several workflows can be orchestrated into a larger workflow, much like building with LEGO™ bricks; the possibilities are boundless. Workflow functions are organized by the _verb_ (e.g. `/find/bulbs`, `/edit/bulb`) to reflect the emphasis on the action, as opposed to the _domain_ (e.g. `/bulb/find`).
- **Narrow down the gaps between concept and implementation.** In the software engineering world, it is quite common to find functional gaps between the original specification versus the final code implementation. The gaps are often traceable to the code writing process, during which there were many technical aspects not mentioned in the design that ended up influencing how the final code is written. And sometimes, because of the structural differences, some parts of the designed flow are missed or mistakenly implemented, such as forgetting to handle edge scenarios. The goal is to write a code which structurally follows the designed flow as close as possible. The workflow function is meant to be written in such a way that mimics a flowchart: it describes end-to-end process flow. That includes entry and exit points, as well as flow controls such as branching, sequence, and iteration. Often forgotten scenarios such as retrying or backtracking failed steps are to be explicitly specified. How exactly this will be implemented is still being decided and thus not covered by this change.

From a workflow function's point of view, the input does not always have to be in the form of an HTTP request. Therefore, rather than using Express idioms for the input (`req.params`, `req.body`, and `req.query`), a framework-agnostic set of idioms is used (`key`, `data`, and `options` respectively). The input is always extracted from the source trigger and converted according to the workflow's input schema.

Another thing introduced in this change is the automatic route generation. An Express app server typically handles incoming requests through the following sequence:
```
 Incoming Request
        |
        V
     Routing
        |
        V
 Input Validation
        |
        V
    Execution
    ____|_____
   |          |
   V          V
Success      Fail
   |__________|
        |
        V
Generate Response
        |
        V
  Send Response
```

From the flow above, only input validation and execution (workflow) is actually unique per request, the rest are boilerplates and thus can be automatically generated using a route builder function.

As for the input validator and the workflow execution, each logic is wrapped in a dedicated middleware. Both are bound by a common constraint: their input type must be identical. Workflow function specifies the type of input it needs in TypeScript, while the input validator needs the same input type be manifested as a `JSONSchemaType` object. AJV ensures that the JSON schema matches with the TypeScript type. The route controller (via `IRouteController` type) then enforces the same generic type for both validator and workflow's input, thereby connecting the two. Finally, the route builder function constructs and chains these middlewares together.

It should be noted that the current implementation still leaves type redundancy problem unresolved (see commentaries on https://github.com/ipanyap/lightbulbs/pull/4). If any, it has added even more redundant types. An example is the redundancy between `IBulb` and `IAddBulbInput`: even if both types consist of similar member names, there are subtle differences such as the required and nullable property of the members. Deriving an input type from the model's type using TypeScript utilities like `Omit`, `Pick`, etc. does not make the work easier than defining the full input type. In the future, there may be a new way to unify the types. For now, though, redundancy is unavoidable.
